### PR TITLE
Feature/dictionary sharing

### DIFF
--- a/src/components/dictionary-page/word-card-desktop.tsx
+++ b/src/components/dictionary-page/word-card-desktop.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 import WordModal from './word-modal';
 import { FvWord } from '../common/data';
 import Modal from '../common/modal/modal';
 
 function WordCardDesktop({ term }: FvWord) {
-  const [showModal, setShowModal] = React.useState(false);
+  const location = useLocation();
+  const [showModal, setShowModal] = React.useState((location.hash === `#${term.source}-${term.entryID}` && window.matchMedia("(min-width: 768px").matches));
   const { word, definition, audio } = term;
 
   return (

--- a/src/components/dictionary-page/word-card-mobile.tsx
+++ b/src/components/dictionary-page/word-card-mobile.tsx
@@ -1,11 +1,19 @@
 import React, { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import WordCard from './word-card';
 import { FvWord } from '../common/data';
 import FullScreenModal from '../common/full-screen-modal/full-screen-modal';
 
 function WordCardMobile({ term }: FvWord) {
-  const [showModal, setShowModal] = React.useState(false);
+  const location = useLocation();
+  const [showModal, setShowModal] = React.useState((location.hash === `#${term.source}-${term.entryID}` && !window.matchMedia("(min-width: 768px").matches));
   const { word, definition, audio } = term;
+  const shareData = {
+    title: "FirstVoices",
+    text: `Learn what the word ${word} means from FirstVoices!`,
+    url: `${window.location.origin}${window.location.pathname}#${term.source}-${term.entryID}`
+  };
+
 
   useEffect(() => {
     if (showModal) {
@@ -53,7 +61,12 @@ function WordCardMobile({ term }: FvWord) {
               </button>
               <button
                 onClick={() => {
-                  // TODO:
+                  if (navigator.share && navigator.canShare(shareData)) {
+                    navigator.share(shareData);
+                  }
+                  else {
+                    navigator.clipboard.writeText(shareData.url);
+                  }
                 }}
               >
                 <i className="fv-share pr-5" />

--- a/src/components/dictionary-page/word-modal.tsx
+++ b/src/components/dictionary-page/word-modal.tsx
@@ -3,6 +3,11 @@ import WordCard from './word-card';
 
 function WordModal({ term }: FvWord) {
   const { word } = term;
+  const shareData = {
+    title: "FirstVoices",
+    text: `Learn what the word ${word} means from FirstVoices!`,
+    url: `${window.location.origin}${window.location.pathname}#${term.source}-${term.entryID}`
+  };
 
   return (
     <div className="p-10">
@@ -22,7 +27,12 @@ function WordModal({ term }: FvWord) {
           <div className="pl-2 pr-2">
             <button
               onClick={() => {
-                console.log('clicked share');
+                if (navigator.share && navigator.canShare(shareData)) {
+                  navigator.share(shareData);
+                }
+                else {
+                  navigator.clipboard.writeText(shareData.url);
+                }
               }}
             >
               <i className="fv-share pr-2" />

--- a/src/components/dictionary-view/dictionary-view.tsx
+++ b/src/components/dictionary-view/dictionary-view.tsx
@@ -1,5 +1,5 @@
 import { dataDict } from '../temp-word-list';
-import { Fragment, useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import WordCardMobile from '../dictionary-page/word-card-mobile';
 import WordCardDesktop from '../dictionary-page/word-card-desktop';
 import { DictionaryType } from '../common/data/enums';
@@ -44,10 +44,10 @@ export function DictionaryView(props: WordsViewProps) {
       />
       {data.map((term) => {
         return (
-          <Fragment key={`${term.source}-${term.entryID}`}>
+          <div id={`${term.source}-${term.entryID}`}>
             <WordCardMobile term={term} />
             <WordCardDesktop term={term} />
-          </Fragment>
+          </div>
         );
       })}{' '}
     </div>


### PR DESCRIPTION
Using navigator.share only works when using https. I was able to verify that sharing works as you would expect using an android emulator, but I was unable to properly test Chrome. The fallback behavior I added is to just copy the url to the clipboard.