### PR TITLE
FW-5469 sound icon alignment

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,14 +1,17 @@
 Description of Changes
 
+-
 
 Checklist
-[] README / documentation has been updated if needed
-[] PR title / commit messages contain Jira ticket number if applicable
-[] Tests have been updated / created if applicable
+
+- [ ] README / documentation has been updated if needed
+- [ ] PR title / commit messages contain Jira ticket number if applicable
+- [ ] Tests have been updated / created if applicable
 
 Reviewers Should Do The Following:
-[] Review the changes here
-[] Pull the branch and test locally
+
+- [ ] Review the changes here
+- [ ] Pull the branch and test locally
 
 Additional Notes
 N/A

--- a/src/components/category-view/category-view.tsx
+++ b/src/components/category-view/category-view.tsx
@@ -141,21 +141,25 @@ export function CategoryView(props: CategoryViewProps) {
               })
               .map((term) => {
                 return (
-                  <Fragment key={`${term.source}-${term.entryID}`}>
+                  <div
+                    key={`${term.source}-${term.entryID}`}
+                    id={`${term.source}-${term.entryID}`}
+                    className="flex w-full"
+                  >
                     <WordCardMobile item={term} />
-                  </Fragment>
+                  </div>
                 );
               })}{' '}
           </div>
         </div>
       </div>
 
-      <div className="flex flex-row hidden md:block pr-5">
+      <div className="hidden md:flex flex-row  px-2">
         <div className={styles['container']}>
-          <div className="flex flex-row">
+          <div className="flex flex-row space-x-2">
             <div
               className={classNames(
-                'overflow-y-auto mr-8',
+                'overflow-y-auto',
                 styles['catsSubCatsContainer']
               )}
             >
@@ -211,9 +215,13 @@ export function CategoryView(props: CategoryViewProps) {
                   })
                   .map((term) => {
                     return (
-                      <Fragment key={`${term.source}-${term.entryID}`}>
+                      <div
+                        key={`${term.source}-${term.entryID}`}
+                        id={`${term.source}-${term.entryID}`}
+                        className="flex w-full"
+                      >
                         <WordCardDesktop item={term} wordWidthClass="w-40" />
-                      </Fragment>
+                      </div>
                     );
                   })}
                 <div className="h-48" />

--- a/src/components/dictionary-page/word-card-desktop.tsx
+++ b/src/components/dictionary-page/word-card-desktop.tsx
@@ -54,28 +54,31 @@ function WordCardDesktop(
         onClick={() => setShowModal(true)}
       >
         <div className="grid grid-flow-col auto-cols-[minmax(0,_2fr)]">
-          <div className="flex grid-flow-col space-x-5 items-center col-span-2">
-            <div className={classNames('flex flex-wrap', wordWidthClass)}>
-              <h1 className="font-bold">
-                {wordLocations
-                  ? applyHighlighting(word, wordLocations, 'word')
-                  : word}
-              </h1>
-            </div>
-            <div className="w-20">
-              {audio?.map((fvAudio: Audio1) => (
-                <i key={fvAudio.filename} className="fv-volume-up" />
-              ))}
+          <div className="flex grid-flow-col items-center col-span-4">
+            <div
+              className={classNames(
+                'flex flex-wrap font-bold text-left',
+                wordWidthClass
+              )}
+            >
+              {wordLocations
+                ? applyHighlighting(word, wordLocations, 'word')
+                : word}
             </div>
           </div>
-          <div className="col-span-4">
-            <h1 className="truncate">
+          <div className="col-span-1">
+            {audio?.map((fvAudio: Audio1) => (
+              <i key={fvAudio.filename} className="fv-volume-up" />
+            ))}
+          </div>
+          <div className="col-span-7 text-left">
+            <p className="truncate">
               {wordLocations
                 ? applyHighlighting(definition, wordLocations, 'definition')
                 : definition}
-            </h1>
+            </p>
           </div>
-          <div className="place-self-end">
+          <div className="col-span-1 flex h-full justify-end items-center">
             <i className="fv-right-open" />
           </div>
         </div>

--- a/src/components/dictionary-page/word-card-mobile.tsx
+++ b/src/components/dictionary-page/word-card-mobile.tsx
@@ -52,12 +52,10 @@ function WordCardMobile(
       >
         <div className="grid grid-cols-10 gap-2 text-left w-full">
           <div className="col-span-8">
-            <div>
-              <h1 className="font-bold">
-                {wordLocations
-                  ? applyHighlighting(word, wordLocations, 'word')
-                  : word}
-              </h1>
+            <div className="font-bold">
+              {wordLocations
+                ? applyHighlighting(word, wordLocations, 'word')
+                : word}
             </div>
             <p className="truncate">
               {wordLocations

--- a/src/components/dictionary-page/word-card-mobile.tsx
+++ b/src/components/dictionary-page/word-card-mobile.tsx
@@ -45,11 +45,12 @@ function WordCardMobile(
 
   return (
     <>
-      <div
-        className="block md:hidden rounded-lg bg-white p-6 m-2 shadow-lg hover:bg-slate-100 cursor-pointer"
+      <button
+        type="button"
+        className="flex md:hidden w-full bg-white p-5 m-2 rounded-lg shadow-lg hover:bg-slate-100 cursor-pointer"
         onClick={() => setShowModal(true)}
       >
-        <div className="grid grid-cols-10 gap-4">
+        <div className="grid grid-cols-10 gap-2 text-left w-full">
           <div className="col-span-8">
             <div>
               <h1 className="font-bold">
@@ -58,22 +59,22 @@ function WordCardMobile(
                   : word}
               </h1>
             </div>
-            <h1 className="truncate">
+            <p className="truncate">
               {wordLocations
                 ? applyHighlighting(definition, wordLocations, 'definition')
                 : definition}
-            </h1>
+            </p>
           </div>
-          <div className="self-center col-span-1">
+          <div className="col-span-1 self-center">
             {audio?.map((fvAudio: { filename: Key | null | undefined }) => (
               <i key={fvAudio.filename} className="fv-volume-up" />
             ))}
           </div>
-          <div className="place-self-end self-center">
+          <div className="col-span-1 place-self-end self-center">
             <i className="fv-right-open" />
           </div>
         </div>
-      </div>
+      </button>
       {showModal && (
         <FullScreenModal onClose={() => closeModal()} actions={null}>
           <WordModal

--- a/src/components/dictionary-view/dictionary-view.tsx
+++ b/src/components/dictionary-view/dictionary-view.tsx
@@ -135,6 +135,7 @@ export function DictionaryView(props: WordsViewProps) {
               <div
                 key={`${term.source}-${term.entryID}`}
                 id={`${term.source}-${term.entryID}`}
+                className="flex w-full"
               >
                 <WordCardMobile item={item} />
                 <WordCardDesktop item={item} wordWidthClass="w-80" />

--- a/src/components/randomized-view/randomized-view.tsx
+++ b/src/components/randomized-view/randomized-view.tsx
@@ -98,6 +98,7 @@ export function RandomizedView(props: WordsViewProps) {
               <div
                 key={`${term.source}-${term.entryID}`}
                 id={`${term.source}-${term.entryID}`}
+                className="flex w-full"
               >
                 <WordCardMobile item={term} />
                 <WordCardDesktop item={term} wordWidthClass="w-80" />

--- a/src/components/sub-nav-desktop/sub-nav-desktop.tsx
+++ b/src/components/sub-nav-desktop/sub-nav-desktop.tsx
@@ -10,7 +10,10 @@ export function SubNavDesktop({ navItems }: SubNavDesktopProps) {
   const location = useLocation();
 
   return (
-    <nav className="sidebar w-[100px] flex flex-col hidden md:block mr-5" role="complementary">
+    <nav
+      className="hidden md:flex flex-col sidebar w-[100px] mr-2"
+      role="complementary"
+    >
       {navItems.map((item) => {
         return (
           <Link

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -48,7 +48,7 @@ module.exports = {
         'color-flashcards-dark': '#4A2954',
         'color-profile-light': '#D6D3D1',
         'color-profile-dark': '#898886',
-        'color-main-header': '#737274',
+        'color-main-header': '#313133',
         phrase: '#C37829',
         song: '#830042',
         story: '#E9C46A',


### PR DESCRIPTION
Description of Changes
- Adjusted the alignment of sound icon and chevron on word cards
- Standardized the spacing of the desktop views for dictionary, category, and randomized 
- Updated `color-main-header` to match fv-web `fv-charcoal`

Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

Reviewers Should Do The Following:
- [x] Review the changes here
- [ ] Pull the branch and test locally

Additional Notes
N/A