### PR TITLE
fw-5848, add audio to cache while browsing

### DIFF
--- a/src/components/common/audio-button/audio.tsx
+++ b/src/components/common/audio-button/audio.tsx
@@ -28,6 +28,12 @@ export function AudioButton({ fvAudio }: AudioButtonProps) {
   useEffect(() => {
     db.hasMediaFile(fvAudio.filename).then((response) => {
       setHasFile(response);
+      if(!response) {
+        console.log("fetching audio file in order to cache it", fvAudio.filename);
+        fetch(fvAudio.filename).then((response) => {
+          console.log("fetched audio file: ", fvAudio.filename, response)
+        })
+      }
       const audioElement = new Audio(fvAudio.filename);
       addAudio(audioElement);
       setAudio(audioElement);


### PR DESCRIPTION
Description of Changes

- Audio files were not triggering the fetch listener, possibly because Audio elements were created in memory and not added to the dom? This explicitly fetches them, which should add them to the cache.
- Additional logging is temporary, for testing
- Needs to be tested on dev

Checklist

- [ ] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

Additional Notes
N/A
