### PR TITLE
FW-5466 Close word modal on desktop if outside is clicked

### DIFF
--- a/src/components/dictionary-page/word-card-desktop.tsx
+++ b/src/components/dictionary-page/word-card-desktop.tsx
@@ -8,11 +8,12 @@ import {
 } from '../common/data';
 import Modal from '../common/modal/modal';
 import { useModal } from '../common/use-modal/use-modal';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { Audio1 } from '@mothertongues/search';
 import { useAudio } from '../contexts/audioContext';
 import classNames from 'classnames';
 import { applyHighlighting } from '../../util/applyHighlighting';
+import useOnClickOutside from '../../util/clickOutside';
 
 function WordCardDesktop(
   props: Readonly<{
@@ -35,6 +36,8 @@ function WordCardDesktop(
   const { setShowModal, showModal, closeModal } = useModal();
   const { stopAll } = useAudio();
 
+  const modalRef = useRef(null);
+
   useEffect(() => {
     const locationHash = `#${term.source}-${term.entryID}`;
     if (
@@ -46,6 +49,11 @@ function WordCardDesktop(
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location]);
+
+  useOnClickOutside(modalRef, () => {
+    closeModal();
+    stopAll();
+  });
 
   return (
     <>
@@ -85,13 +93,15 @@ function WordCardDesktop(
       </button>
       {showModal && (
         <Modal onClose={() => closeModal()}>
-          <WordModal
-            term={term}
-            onClose={() => {
-              closeModal();
-              stopAll();
-            }}
-          />
+          <div ref={modalRef}> {/* Add the ref to the modal wrapper */}
+            <WordModal
+              term={term}
+              onClose={() => {
+                closeModal();
+                stopAll();
+              }}
+            />
+          </div>
         </Modal>
       )}
     </>

--- a/src/components/dictionary-page/word-card-desktop.tsx
+++ b/src/components/dictionary-page/word-card-desktop.tsx
@@ -93,7 +93,7 @@ function WordCardDesktop(
       </button>
       {showModal && (
         <Modal onClose={() => closeModal()}>
-          <div ref={modalRef}> {/* Add the ref to the modal wrapper */}
+          <div ref={modalRef}>
             <WordModal
               term={term}
               onClose={() => {


### PR DESCRIPTION
Description of Changes

- Re-uses the useOnClickOutside function in `WordCardDesktop` to close the modal if the user clicks outside of it.

Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] ~~Tests have been updated / created if applicable~~

Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] ~~Pull the branch and test locally~~

Additional Notes
N/A
