### PR TITLE
fw-5800, more info when clearing media cache

### DIFF
--- a/src/components/common/confirm/confirm.tsx
+++ b/src/components/common/confirm/confirm.tsx
@@ -1,5 +1,3 @@
-import classNames from 'classnames';
-import { useButtonStyle } from '../hooks';
 import Modal from '../modal/modal';
 
 type ConfirmDialogProps = {
@@ -28,22 +26,19 @@ export function ConfirmDialog({
     closeModal();
   };
 
-  const primaryButtonStyle = useButtonStyle('primary', 'button');
-  const secondaryButtonStyle = useButtonStyle('secondary', 'button');
-
   return (
     <Modal title={title} onClose={closeModal} showCloseButton={false} closeOnOutsideClick={false}>
       <div className="p-4">{message}</div>
       <div className="flex justify-end">
         <div className="p-4">
           <button
-            className={classNames('mr-2', primaryButtonStyle)}
+            className="btn-contained bg-secondary mr-2"
             onClick={handleConfirm}
           >
             {confirmLabel}
           </button>
           <button
-            className={classNames('mr-2', secondaryButtonStyle)}
+            className="btn-contained bg-primary mr-2"
             onClick={closeModal}
           >
             {cancelLabel}

--- a/src/components/settings-view/settings-view.tsx
+++ b/src/components/settings-view/settings-view.tsx
@@ -1,4 +1,3 @@
-import { useButtonStyle } from '../common/hooks';
 import styles from './settings-view.module.css';
 import IndexedDBService from '../../services/indexedDbService';
 import { useEffect, useState } from 'react';
@@ -8,26 +7,35 @@ import ConfirmDialog from '../common/confirm/confirm';
 export interface SettingsViewProps {}
 
 export function SettingsView(props: SettingsViewProps) {
-  const primaryButtonStyle = useButtonStyle('primary', 'button');
 
   const [db, setDb] = useState<IndexedDBService>();
+  const [mediaCount, setMediaCount] = useState(0);
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
 
   useEffect(() => {
     setDb(new IndexedDBService('firstVoicesIndexedDb'));
   }, []);
 
+  useEffect(() => {
+    if(db){
+      updateMediaCount();
+    }
+  }, [db]);
+
   return (
     <>
       <div className={styles['container']}>
         <div className="m-4">
-          <button
-            className={primaryButtonStyle}
+          <p className="mb-3">Media files are stored in a local cache, so they are available when you are offline. You can clear this cache to free up space on your device, but the files will stop being available offline until you download them again.</p>
+          <p className="mb-6">Currently you have <span id="localMediaCount">{mediaCount}</span> files in your local cache.</p>
+
+          <p><button
+            className="btn-contained bg-secondary"
             onClick={() => setShowConfirmDialog(true)}
           >
             Clear Media Cache
             {/* <i className=""></i> */}
-          </button>
+          </button></p>
         </div>
       </div>
       {showConfirmDialog && (
@@ -41,8 +49,14 @@ export function SettingsView(props: SettingsViewProps) {
     </>
   );
 
+  async function updateMediaCount() {
+    const count = await db?.getMediaCount();
+    setMediaCount(count || 0);
+  }
+
   function handleClearCache() {
     db?.clearMediaFilesCollection();
+    updateMediaCount();
   }
 }
 

--- a/src/services/indexedDbService.ts
+++ b/src/services/indexedDbService.ts
@@ -131,6 +131,11 @@ class IndexedDBService {
     return mediaFile;
   }
 
+  async getMediaCount(): Promise<number> {
+    const store = await this.getMediaStore();
+    return store.count();
+  }
+
   async saveData(key: string, data: any) {
     const db = await this.database;
     const transaction = db.transaction('data', 'readwrite');


### PR DESCRIPTION
Description of Changes

- added messages with count of cached files
- switched to standard button styles
- swapped "confirm" to be the red button instead of "cancel"-- the one other place this dialog is used in for the bulk download, where I think a red confirm button also makes sense

Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

Additional Notes
N/A
