### PR TITLE
Fw-5861, support loading subdomains on localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ $ npm run build
 $ npm start
 ```
 
+5. Access the application at `[sitename].localhost:3000`
+
+    a. If you are switching between different sites locally, you may need to clear your local data in between depending on your browser.
+
+    b. If you want custom icons and site titles locally, you need to add the required `manifest.[sitename].json` file in the `public` folder, as well as a `[sitename]` subfolder containing the required icons. (See [Adding new dialects/languages](#adding-new-dialectslanguages) below for file specs.)
+
+
 ## Running the tests
 
 ```bash

--- a/public/index.html
+++ b/public/index.html
@@ -30,7 +30,7 @@
     -->
     <script>
       const hostnameParts = window.location.hostname.split('.');
-      const subdomain = hostnameParts.length > 2 ? hostnameParts[0] : 'default';
+      const subdomain = hostnameParts[0];
       const manifestUrl = `%PUBLIC_URL%/manifest.${subdomain}.json`;
 
       // link the manifest

--- a/src/util/getCurrentDialect.ts
+++ b/src/util/getCurrentDialect.ts
@@ -1,8 +1,5 @@
 export const getCurrentDialect = () => {
   const hostname = window.location.hostname;
-  if (hostname.includes('localhost')) {
-    return 'smalgyax';
-  }
   return hostname.slice(
     0,
     hostname.indexOf(`.${process.env.REACT_APP_BASE_HOST}`)


### PR DESCRIPTION
Description of Changes

- uses the real subdomain to load the manifest and data, rather than always defaulting to Sm'algyax

Checklist

- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

Reviewers Should Do The Following:

- [ ] Review the changes here
- [ ] Pull the branch and test locally

Additional Notes
N/A
