### PR TITLE
Fw-5884, store media files as array buffers instead of blobs

### DIFF
--- a/src/services/indexedDbService.ts
+++ b/src/services/indexedDbService.ts
@@ -80,18 +80,22 @@ class IndexedDBService {
     return bookmarks;
   }
 
-  async hasMediaFile(url: string): Promise<boolean> {
-    const db = await this.database;
-    const transaction = db.transaction(['mediaFiles'], 'readonly');
-    const store = transaction.objectStore('mediaFiles');
-    const mediaFile = await store.get(url);
-    return mediaFile !== undefined;
-  }
-
   async getMediaStore() {
     const db = await this.database;
     const transaction = db.transaction('mediaFiles', 'readwrite');
     return transaction.objectStore('mediaFiles');
+  }
+
+  async getReadOnlyMediaStore(){
+    const db = await this.database;
+    const transaction = db.transaction('mediaFiles', 'readonly');
+    return transaction.objectStore('mediaFiles');
+  }
+  
+  async hasMediaFile(url: string): Promise<boolean> {
+    const store = await this.getReadOnlyMediaStore();
+    const mediaFile = await store.get(url);
+    return mediaFile !== undefined;
   }
 
   async addMediaFile(url: string, file: Blob) {
@@ -132,7 +136,7 @@ class IndexedDBService {
   }
 
   async getMediaCount(): Promise<number> {
-    const store = await this.getMediaStore();
+    const store = await this.getReadOnlyMediaStore();
     return store.count();
   }
 


### PR DESCRIPTION
Description of Changes

- webkit/ios sometimes truncates blobs stored in IndexedDB, so switch to storing our cached media files as array buffers instead
- bonus: minor refactoring in the media store code

Checklist

- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

Reviewers Should Do The Following:

- [ ] Review the changes here
- [ ] Pull the branch and test locally

Additional Notes
N/A
