### PR TITLE
Fw-5884, prevent broken audio button when switching from offline to online

### DIFF
--- a/src/components/common/audio-button/audio.tsx
+++ b/src/components/common/audio-button/audio.tsx
@@ -27,16 +27,7 @@ export function AudioButton({ fvAudio }: Readonly<AudioButtonProps>) {
     setAudio(audioElement);
 
     db.hasMediaFile(fvAudio.filename).then((hasFile) => {
-      if (!hasFile) {
-        // try fetching the file if it isn't cached yet
-        fetch(fvAudio.filename, { mode: 'cors' })
-          .then((response) => db.hasMediaFile(fvAudio.filename))
-          .then((hasFile) => {
-            setHasFile(hasFile);
-          });
-      } else {
-        setHasFile(hasFile);
-      }
+      setHasFile(hasFile);
     });
     return () => {
       if (audio) {
@@ -44,7 +35,7 @@ export function AudioButton({ fvAudio }: Readonly<AudioButtonProps>) {
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [isOnline]);
 
   useEffect(() => {
     if (audio) {

--- a/src/components/dictionary-view/word-modal.tsx
+++ b/src/components/dictionary-view/word-modal.tsx
@@ -14,7 +14,6 @@ export interface WordModalProps {
 }
 
 function WordModal({ term, onClose }: Readonly<WordModalProps>) {
-  console.log(term);
   const bookmark: Bookmark = useMemo(() => {
     return {
       id: term.entryID,

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -197,7 +197,6 @@ async function getFileFromResponse(response: Response, filename: string): Promis
   const blob = await response.blob();
 
   if(blob) {
-    console.log("Making blob into file: ", filename, blob.type, blob, response);
     return new File([blob], filename);
   }
 


### PR DESCRIPTION
Description of Changes

- Audio button would incorrectly show as enabled in a specific case, even though it couldn't play. This fixes it by re-calculating the "hasFile" status when the online status changes.
- bonus: remove some extra logs

Checklist

- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

Reviewers Should Do The Following:

- [ ] Review the changes here
- [ ] Pull the branch and test locally

Additional Notes
N/A
