### PR TITLE
FW-5885 Use custom sort order in dictionary lists

### DIFF
--- a/src/components/dictionary-view/dictionary-view.tsx
+++ b/src/components/dictionary-view/dictionary-view.tsx
@@ -7,6 +7,7 @@ import { DictionaryType, FvWord } from '../common/data';
 import MultiSwitch from '../common/multi-switch/multi-switch';
 import { useDictionaryData } from '../dictionary-page/dictionary-page';
 import { SearchContext } from '../contexts/searchContext';
+import sortByCustomOrder from '../../util/sortByCustomOrder';
 
 /* eslint-disable-next-line */
 export interface DictionaryViewProps {}
@@ -74,7 +75,9 @@ export function DictionaryView(props: DictionaryViewProps) {
   // Checking for searchResults
   useEffect(() => {
     if (!searchContext?.searchResults) {
-      setDataUnfiltered(dictionaryData);
+      setDataUnfiltered(dictionaryData.sort((a, b) => {
+        return sortByCustomOrder(a, b);
+      }));
     } else if (searchContext.searchResults) {
       setDataUnfiltered(searchContext.searchResults);
     }

--- a/src/util/sortByCustomOrder.ts
+++ b/src/util/sortByCustomOrder.ts
@@ -1,0 +1,14 @@
+// FPCC
+import { FvWord } from '../components/common/data';
+
+function sortByCustomOrder(a: FvWord, b: FvWord) {
+  const len = Math.min(a.sorting_form.length, b.sorting_form.length);
+  for (let i = 0; i < len; i++) {
+    if (a.sorting_form[i] !== b.sorting_form[i]) {
+      return a.sorting_form[i] - b.sorting_form[i];
+    }
+  }
+  return a.sorting_form.length - b.sorting_form.length;
+}
+
+export default sortByCustomOrder;

--- a/src/util/useStartsWithChar.ts
+++ b/src/util/useStartsWithChar.ts
@@ -12,6 +12,14 @@ export const useStartsWithChar = (
     if (dictionaryData && character.sortingFormNum !== undefined) {
       const entries = [...dictionaryData].filter((entry) => {
         return entry.sorting_form[0] === character.sortingFormNum;
+      }).sort((a, b) => {
+        const len = Math.min(a.sorting_form.length, b.sorting_form.length);
+        for (let i = 0; i < len; i++) {
+          if (a.sorting_form[i] !== b.sorting_form[i]) {
+            return a.sorting_form[i] - b.sorting_form[i];
+          }
+        }
+        return a.sorting_form.length - b.sorting_form.length;
       });
       setEntriesStartingWith(entries);
     }

--- a/src/util/useStartsWithChar.ts
+++ b/src/util/useStartsWithChar.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 // FPCC
 import { FvCharacter, FvWord } from '../components/common/data';
+import sortByCustomOrder from './sortByCustomOrder';
 
 export const useStartsWithChar = (
   dictionaryData: FvWord[],
@@ -13,13 +14,7 @@ export const useStartsWithChar = (
       const entries = [...dictionaryData].filter((entry) => {
         return entry.sorting_form[0] === character.sortingFormNum;
       }).sort((a, b) => {
-        const len = Math.min(a.sorting_form.length, b.sorting_form.length);
-        for (let i = 0; i < len; i++) {
-          if (a.sorting_form[i] !== b.sorting_form[i]) {
-            return a.sorting_form[i] - b.sorting_form[i];
-          }
-        }
-        return a.sorting_form.length - b.sorting_form.length;
+        return sortByCustomOrder(a, b);
       });
       setEntriesStartingWith(entries);
     }


### PR DESCRIPTION
Description of Changes

- Adds a simple function `sortByCustomOrder` that uses the `FvWord`'s `sorting_form` propterty to sort by custom order.
- Uses this function to sort the "word starts with" and dictionary pages by custom order.

Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] ~~Tests have been updated / created if applicable~~

Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

Additional Notes
N/A
