### PR TITLE
FW-5749 fix WOTD modal and install prompt competing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,14 +7,17 @@ import MobileNav from './components/common/mobile-nav/mobile-nav';
 import { LoadingSpinner } from './components/common/loading-spinner/loading-spinner';
 import { navItems, extraNavItems } from './constants/navigation';
 import InstallPrompt from './components/install-prompt/install-prompt';
+import { InstallPromptProvider } from './components/contexts/installPromptContext';
 
 export function App() {
   return (
     <Suspense fallback={<LoadingSpinner />}>
-      <Header navItems={navItems} extraNavItems={extraNavItems} />
-      <Outlet />
-      <InstallPrompt />
-      <MobileNav navItems={navItems} extraNavItems={extraNavItems} />
+      <InstallPromptProvider>
+        <Header navItems={navItems} extraNavItems={extraNavItems} />
+        <Outlet />
+        <InstallPrompt />
+        <MobileNav navItems={navItems} extraNavItems={extraNavItems} />
+      </InstallPromptProvider>
     </Suspense>
   );
 }

--- a/src/components/contexts/installPromptContext.tsx
+++ b/src/components/contexts/installPromptContext.tsx
@@ -1,7 +1,9 @@
 import {
   ReactNode,
   createContext,
+  useCallback,
   useEffect,
+  useMemo,
   useState,
 } from 'react';
 
@@ -39,7 +41,7 @@ export const InstallPromptProvider = ({ children }: InstallPromptProviderProps) 
     };
   }, []);
 
-  const handleInstallPrompt = async () => {
+  const handleInstallPrompt = useCallback(async () => {
     if (window.matchMedia('(display-mode: standalone)').matches) {
       return;
     }
@@ -48,14 +50,22 @@ export const InstallPromptProvider = ({ children }: InstallPromptProviderProps) 
       deferredPrompt.prompt();
       setDeferredPrompt(null);
     }
-  };
+  }, [deferredPrompt]);
+
+  const installPromptContext = useMemo(() => {
+    return {
+      showInstallPrompt,
+      setShowInstallPrompt,
+      handleInstallPrompt,
+    };
+  }, [showInstallPrompt, setShowInstallPrompt, handleInstallPrompt]);
+
 
   return (
-    <InstallPromptContext.Provider value={{ showInstallPrompt, setShowInstallPrompt, handleInstallPrompt }}>
+    <InstallPromptContext.Provider value={installPromptContext as unknown as InstallPromptContextType}>
       {children}
     </InstallPromptContext.Provider>
   );
 };
-
 
 

--- a/src/components/contexts/installPromptContext.tsx
+++ b/src/components/contexts/installPromptContext.tsx
@@ -1,0 +1,61 @@
+import {
+  ReactNode,
+  createContext,
+  useEffect,
+  useState,
+} from 'react';
+
+type InstallPromptContextType = {
+  showInstallPrompt: boolean;
+  setShowInstallPrompt: (show: boolean) => void;
+  handleInstallPrompt: () => void;
+}
+
+export const InstallPromptContext = createContext<InstallPromptContextType>({
+  showInstallPrompt: false,
+  setShowInstallPrompt: () => {},
+  handleInstallPrompt: () => {},
+});
+
+export interface InstallPromptProviderProps {
+  children: ReactNode;
+}
+
+export const InstallPromptProvider = ({ children }: InstallPromptProviderProps) => {
+  const [showInstallPrompt, setShowInstallPrompt] = useState(false);
+  const [deferredPrompt, setDeferredPrompt] = useState<any>(null);
+
+  useEffect(() => {
+    const handleBeforeInstallPrompt = (e: Event) => {
+      e.preventDefault();
+      setDeferredPrompt(e);
+      setShowInstallPrompt(true);
+    };
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+    };
+  }, []);
+
+  const handleInstallPrompt = async () => {
+    if (window.matchMedia('(display-mode: standalone)').matches) {
+      return;
+    }
+    if (deferredPrompt) {
+      setShowInstallPrompt(false);
+      deferredPrompt.prompt();
+      setDeferredPrompt(null);
+    }
+  };
+
+  return (
+    <InstallPromptContext.Provider value={{ showInstallPrompt, setShowInstallPrompt, handleInstallPrompt }}>
+      {children}
+    </InstallPromptContext.Provider>
+  );
+};
+
+
+

--- a/src/components/dictionary-page/word-of-the-day.tsx
+++ b/src/components/dictionary-page/word-of-the-day.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 
 // FPCC
 import WordModal from '../dictionary-view/word-modal';
@@ -8,6 +8,7 @@ import { FvWord } from '../common/data';
 import FullScreenModal from '../common/full-screen-modal/full-screen-modal';
 import { LoadingSpinner } from '../common/loading-spinner/loading-spinner';
 import { useAudio } from '../contexts/audioContext';
+import { InstallPromptContext } from '../contexts/installPromptContext';
 
 export interface WordOfTheDayProps {
   dictionaryData: FvWord[];
@@ -16,19 +17,20 @@ export interface WordOfTheDayProps {
 function WordOfTheDay({ dictionaryData }: Readonly<WordOfTheDayProps>) {
   const today = new Date();
   const { stopAll } = useAudio();
+  const { showInstallPrompt } = useContext(InstallPromptContext);
 
   const [showModal, setShowModal] = React.useState(false);
   const [data, setData] = useState<any>(null);
 
   useEffect(() => {
     if (
-      today.toDateString() !== (localStorage.getItem('lastWOTDSeenOn') ?? '')
+      today.toDateString() !== (localStorage.getItem('lastWOTDSeenOn') ?? '') && !showInstallPrompt
     ) {
       setShowModal(true);
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [showInstallPrompt]);
 
   useEffect(() => {
     if (showModal) {

--- a/src/components/dictionary-view/word-modal.tsx
+++ b/src/components/dictionary-view/word-modal.tsx
@@ -14,7 +14,6 @@ export interface WordModalProps {
 }
 
 function WordModal({ term, onClose }: Readonly<WordModalProps>) {
-  console.log(term);
   const bookmark: Bookmark = useMemo(() => {
     return {
       id: term.entryID,

--- a/src/components/install-prompt/install-prompt.tsx
+++ b/src/components/install-prompt/install-prompt.tsx
@@ -1,14 +1,14 @@
-import React, { useEffect, useState } from 'react';
+import { useContext } from 'react';
 
 // FPCC
 import Modal from '../common/modal/modal';
 import fpccLogo from '../../assets/images/fpccLogoColorWhite.svg';
 import fpcfLogo from '../../assets/images/fpcfLogoWhite.svg';
 import useSiteTitleFromManifest from '../../util/useSiteTitleFromManifest';
+import { InstallPromptContext } from '../contexts/installPromptContext';
 
 export function InstallPrompt() {
-  const [showInstallPrompt, setShowInstallPrompt] = useState(false);
-  const [deferredPrompt, setDeferredPrompt] = useState<any>(null);
+  const { showInstallPrompt, handleInstallPrompt, setShowInstallPrompt } = useContext(InstallPromptContext);
 
   // Site information from manifest and hostname
   const hostnameParts = window.location.hostname.split('.');
@@ -17,31 +17,6 @@ export function InstallPrompt() {
   const siteTitle = useSiteTitleFromManifest(manifestUrl);
   const siteURL = `https://www.firstvoices.com/${subdomain}/`;
   const logoURL = `${process.env.PUBLIC_URL}/${subdomain}/logo192.png`;
-
-  useEffect(() => {
-    const handleBeforeInstallPrompt = (e: Event) => {
-      e.preventDefault();
-      setDeferredPrompt(e);
-      setShowInstallPrompt(true);
-    };
-
-    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
-
-    return () => {
-      window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
-    };
-  }, []);
-
-  const handleInstallPrompt = async () => {
-    if (window.matchMedia('(display-mode: standalone)').matches) {
-      return;
-    }
-    if (deferredPrompt) {
-      setShowInstallPrompt(false);
-      deferredPrompt.prompt();
-      setDeferredPrompt(null);
-    }
-  };
 
   return (
     <>
@@ -57,7 +32,7 @@ export function InstallPrompt() {
             <p className="mb-4 text-lg">
               Browse words and phrases in the dictionary, practice with flashcards, bookmark content and more.
             </p>
-            <button onClick={handleInstallPrompt} className="bg-blue-500 text-white px-8 py-3 rounded-lg text-lg mb-4">
+            <button onClick={handleInstallPrompt} className="bg-secondary-500 text-white px-8 py-3 rounded-lg text-lg mb-4">
               Install App
             </button>
             <p className="mb-1 text-sm">


### PR DESCRIPTION
Description of Changes

- Moves the code for `showInstallPrompt` to its own context, and uses that context to determine if the WOTD modal or the install prompt should be shown.
- Changes the install prompt button colour

Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] ~~Tests have been updated / created if applicable~~

Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

Additional Notes
N/A
