### PR TITLE
Fw-5874, re-focus search box if it loses focuse during scrolling

### DIFF
--- a/src/components/common/search-input/search-input.tsx
+++ b/src/components/common/search-input/search-input.tsx
@@ -46,6 +46,7 @@ export function SearchInput(props: Readonly<SearchInputProps>) {
         onKeyUp={onKeyUp}
         placeholder="Search"
         className="p-2 rounded-l-lg h-7 border border-gray-400 w-full shadow-inner"
+        id="search-input"
       />
       <button
         onClick={clearSearch}

--- a/src/components/dictionary-page/word-of-the-day.tsx
+++ b/src/components/dictionary-page/word-of-the-day.tsx
@@ -83,7 +83,6 @@ function WordOfTheDay({ dictionaryData }: Readonly<WordOfTheDayProps>) {
   if (data) {
     if (showModal) {
       if (window.matchMedia('(min-width: 768px').matches) {
-        console.info('larger than 768px');
         return (
           <Modal onClose={() => wordOfTheDaySeen()}>
             <div className="w-full text-center text-3xl mb-5">
@@ -99,7 +98,6 @@ function WordOfTheDay({ dictionaryData }: Readonly<WordOfTheDayProps>) {
           </Modal>
         );
       } else if (!window.matchMedia('(min-width: 768px').matches) {
-        console.info('smaller than 768px');
         return (
           <FullScreenModal onClose={() => wordOfTheDaySeen()}>
             <div className="flex w-full text-center text-3xl mb-5">

--- a/src/components/dictionary-view/dictionary-view.tsx
+++ b/src/components/dictionary-view/dictionary-view.tsx
@@ -21,6 +21,11 @@ export function DictionaryView(props: DictionaryViewProps) {
   const searchContext = useContext(SearchContext);
 
   const handleScroll = () => {
+    // see fw-6019 to remove this bespoke scroll handling
+    const currentFocus = document.activeElement; // returns an Element
+    const searchInput = document.getElementById("search-input"); // returns an HTMLElement with a focus() method
+    const isSearchFocussed = currentFocus && (currentFocus?.id === searchInput?.id)
+
     const windowHeight = window.innerHeight;
     const container = document.getElementById('wordList');
     if (!container) return;
@@ -30,6 +35,11 @@ export function DictionaryView(props: DictionaryViewProps) {
 
     if (windowHeight + scrollTop >= documentHeight - containerHeight - 20) {
       setVisibleItems((prevVisibleItems) => prevVisibleItems + 20);
+    }
+
+    if(isSearchFocussed){
+      // refocus the search box which is necessary for some browsers, see fw-5874
+      searchInput?.focus();
     }
   };
 


### PR DESCRIPTION
Description of Changes

- potential fix for android ff when installed as a pwa, where opening the keyboard causes the searchbox to immediately lose focus (thus closing the keyboard)

Checklist

- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

Reviewers Should Do The Following:

- [ ] Review the changes here
- [ ] Pull the branch and test locally

Additional Notes
N/A
