### PR TITLE
FW-6054 remove UI references to offline media

### DIFF
--- a/src/components/alphabet-view/selected-letter-display.tsx
+++ b/src/components/alphabet-view/selected-letter-display.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 // FPCC
 import { CopyButton } from './copy-button';
-import { DownloadButton } from './download-button';
+// import { DownloadButton } from './download-button';
 import AudioControl from '../common/audio-control/audio-control';
 import { FvCharacter, FVMedia, FvWord } from '../common/data';
 
@@ -26,13 +26,13 @@ export function SelectedLetterDisplay({
       {audioCount === 0 && (
         <div className="flex w-full justify-center">
           <CopyButton selected={selected} />
-          <DownloadButton selected={selected} dictionaryData={dictionaryData} />
+          {/* <DownloadButton selected={selected} dictionaryData={dictionaryData} /> */}
         </div>
       )}
       {audioCount === 1 && (
-        <div className="grid grid-cols-3">
+        <div className="grid grid-cols-2">
           <CopyButton selected={selected} />
-          <DownloadButton selected={selected} dictionaryData={dictionaryData} />
+          {/* <DownloadButton selected={selected} dictionaryData={dictionaryData} /> */}
           {selected?.relatedAudio.map((fvAudio: FVMedia) => {
             return (
               <AudioControl
@@ -49,12 +49,12 @@ export function SelectedLetterDisplay({
           <div className="flex w-full justify-center">
             <CopyButton selected={selected} />
           </div>
-          <div className="flex w-full justify-center">
+          {/* <div className="flex w-full justify-center">
             <DownloadButton
               selected={selected}
               dictionaryData={dictionaryData}
             />
-          </div>
+          </div> */}
           <div className="flex justify-evenly mt-5">
             {selected?.relatedAudio.map((fvAudio: FVMedia) => {
               return (

--- a/src/components/common/audio-control/audio-control.tsx
+++ b/src/components/common/audio-control/audio-control.tsx
@@ -73,7 +73,7 @@ export function AudioControl({
 
       <Alert
         type={'warning'}
-        message="Audio file not downloaded.  Please access when you have access to internet in order to download content."
+        message="Audio files are not available offline. Please go online to listen to this audio."
         showDismissButton={true}
         showAlert={showAlert}
         dismissAlert={function (): void {

--- a/src/components/common/image/image.tsx
+++ b/src/components/common/image/image.tsx
@@ -43,7 +43,7 @@ export function FvImage({
 
       <Alert
         type={'warning'}
-        message="This image content has not been downloaded.  Please access when you have access to internet in order to download content."
+        message="Images are not available offline. Please go online to access this image."
         showDismissButton={true}
         showAlert={showAlert}
         dismissAlert={function (): void {

--- a/src/components/common/video/video.tsx
+++ b/src/components/common/video/video.tsx
@@ -43,7 +43,7 @@ export function FvVideo({
 
       <Alert
         type={'warning'}
-        message="This video content has not been downloaded.  Please access when you have access to internet in order to download content."
+        message="Videos are not available offline. Please go online to access this video."
         showDismissButton={true}
         showAlert={showAlert}
         dismissAlert={function (): void {

--- a/src/components/settings-view/settings-view.tsx
+++ b/src/components/settings-view/settings-view.tsx
@@ -27,10 +27,8 @@ export function SettingsView(props: SettingsViewProps) {
       <div className={styles['container']}>
         <div className="m-4">
           <p className="mb-3">
-            Media files are stored in a local cache, so they are available when
-            you are offline. You can clear this cache to free up space on your
-            device, but the files will stop being available offline until you
-            download them again.
+            We store media files to assist with app performance. You can clear
+            this cache to free up space on your device.
           </p>
           <p className="mb-6">
             Currently you have <span id="localMediaCount">{mediaCount}</span>{' '}
@@ -43,7 +41,6 @@ export function SettingsView(props: SettingsViewProps) {
               onClick={() => setShowConfirmDialog(true)}
             >
               Clear Media Cache
-              {/* <i className=""></i> */}
             </button>
           </p>
         </div>


### PR DESCRIPTION
Description of Changes

- hide the download button on alphabet pages
- update the text on the media cache page to:  "We store media files to assist with app performance. You can clear this cache to free up space on your device."
- update the text that pops up on placeholder media while offline

Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

Additional Notes
N/A
