### PR TITLE
FW-6222 Updated webpack config to copy images to the root folder instead

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -44,11 +44,11 @@
       // Link the logos
       const faviconLink = document.createElement('link');
       faviconLink.rel = 'icon';
-      faviconLink.href = `${origin}/assets/${subdomain}/favicon.ico`;
+      faviconLink.href = `${origin}/${subdomain}/favicon.ico`;
       document.head.appendChild(faviconLink);
       const logoLink = document.createElement('link');
       logoLink.rel = 'apple-touch-icon';
-      logoLink.href = `${origin}/assets/${subdomain}/logo192.png`;
+      logoLink.href = `${origin}/${subdomain}/logo192.png`;
       document.head.appendChild(logoLink);
 
       // customize the title for this language

--- a/src/components/about-view/about-view.tsx
+++ b/src/components/about-view/about-view.tsx
@@ -17,7 +17,7 @@ export function AboutView({ children }: Readonly<AboutViewProps>) {
   const manifestUrl = `${origin}/assets/manifest.${subdomain}.json`
   const siteTitle = useSiteTitleFromManifest(manifestUrl)
   const siteURL = `https://www.firstvoices.com/${subdomain}/`
-  const logoURL = `${origin}/assets/${subdomain}/logo192.png`
+  const logoURL = `${origin}/${subdomain}/logo192.png`
 
   return (
     <div data-testid="AboutView" className="max-w-3xl mx-auto">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -142,8 +142,17 @@ module.exports = {
           from: 'public',
           to: 'assets',
           globOptions: {
-            ignore: ['**/index.html', '**/robots.txt'],
+            ignore: ['**/index.html', '**/robots.txt', '**/*.{png, jpg, jpeg, ico, gif}'],
           },
+        },
+        {
+          // Images are copied to root instead of assets for FW-6222.
+          from: 'public',
+          to: '.',
+          globOptions: {
+            glob: '**/*.{png, jpg, jpeg, ico, gif}',
+            ignore: ['**/index.html', '**/robots.txt'],
+          }
         },
         {
           from: 'public/robots.txt',


### PR DESCRIPTION
### Description of Changes
- The images (logos, other pngs, favicons etc.) are now copied over to the root directory of the build instead of the relevant assets folder to fix the logo reference from fv-web.

### Checklist

- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~

### Reviewers Should Do The Following:

- [x] Review the changes here
- ~Pull the branch and test locally~

### Additional Notes

N/A
