### PR TITLE
FW-5797: Download button state should reflect downloaded media

### DIFF
--- a/src/components/alphabet-view/download-button.tsx
+++ b/src/components/alphabet-view/download-button.tsx
@@ -26,6 +26,28 @@ export function DownloadButton({ dictionaryData, selected }: Readonly<DownloadBu
   const { entriesStartingWith } = useStartsWithChar(dictionaryData, selected)
   const { setNotification } = useNotification()
   const [areAssetsCached, setAreAssetsCached] = useState(false)
+  const [isCheckingCache, setIsCheckingCache] = useState(true)
+
+  const checkCache = async () => {
+    setIsCheckingCache(true)
+    if (mediaList.length === 0) {
+      setAreAssetsCached(true)
+      setIsCheckingCache(false)
+    }
+
+    const db = new IndexedDBService('firstVoicesIndexedDb')
+    const result = await db.hasAllMediaFiles(mediaList)
+
+    setAreAssetsCached(result)
+    setIsCheckingCache(false)
+  }
+
+  const getButtonLabel = () => {
+    if (isCheckingCache) return 'Checking media...'
+    if (mediaList.length === 0) return 'No related media'
+    if (areAssetsCached) return 'All media downloaded'
+    return 'Download related media files'
+  }
 
   const mediaList = useMemo(() => {
     const set = new Set<string>()
@@ -42,39 +64,10 @@ export function DownloadButton({ dictionaryData, selected }: Readonly<DownloadBu
   }, [entriesStartingWith])
 
   useEffect(() => {
-    // To prevent setting state on an unmounted component in case
-    // the async function finishes after the user has moved away
-    let isMounted = true
-
-    async function checkCache() {
-      if (mediaList.length === 0) {
-        if (isMounted) setAreAssetsCached(true)
-        return
-      }
-
-      const db = new IndexedDBService('firstVoicesIndexedDb')
-      const result = await db.hasAllMediaFiles(mediaList)
-
-      if (isMounted) setAreAssetsCached(result)
-    }
-
     checkCache()
-
-    return () => {
-      isMounted = false
-    }
   }, [mediaList])
 
-  let buttonLabel = ''
-
-  if (mediaList.length === 0) {
-    buttonLabel = 'No related media'
-  } else if (areAssetsCached) {
-    buttonLabel = 'All media downloaded'
-  } else {
-    buttonLabel = 'Download related media files'
-  }
-  const buttonDisabled = mediaList.length === 0 || areAssetsCached || currentlyDownloading
+  const buttonDisabled = mediaList.length === 0 || isCheckingCache || areAssetsCached || currentlyDownloading
 
   return (
     <>
@@ -92,7 +85,7 @@ export function DownloadButton({ dictionaryData, selected }: Readonly<DownloadBu
           }
         >
           <p className="text-xl">
-            {buttonLabel} <span className="fv-cloud-arrow-down-regular justify-self-end" />
+            {getButtonLabel()} <span className="fv-cloud-arrow-down-regular justify-self-end" />
           </p>
         </button>
       </div>
@@ -171,6 +164,7 @@ export function DownloadButton({ dictionaryData, selected }: Readonly<DownloadBu
       await Promise.all(promises)
       setCurrentlyDownloading(false)
       setShowDownloadProgress(false)
+      checkCache()
     }
   }
 }

--- a/src/components/alphabet-view/download-button.tsx
+++ b/src/components/alphabet-view/download-button.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import axios from 'axios'
 import { Audio1, DictionaryEntryExportFormat } from '@mothertongues/search'
 
@@ -10,6 +10,7 @@ import Modal from 'components/common/modal/modal'
 import { FvCharacter, FvWord } from 'components/common/data'
 import { useStartsWithChar } from 'util/useStartsWithChar'
 import { useNotification } from 'components/contexts/notificationContext'
+import IndexedDBService from 'services/indexedDbService'
 
 export interface DownloadButtonProps {
   dictionaryData: DictionaryEntryExportFormat[]
@@ -24,20 +25,56 @@ export function DownloadButton({ dictionaryData, selected }: Readonly<DownloadBu
   const { isOnline } = useDetectOnlineStatus()
   const { entriesStartingWith } = useStartsWithChar(dictionaryData, selected)
   const { setNotification } = useNotification()
+  const [areAssetsCached, setAreAssetsCached] = useState(false)
 
-  const getMediaCount = () => {
-    let mediaCount = 0
+  const mediaList = useMemo(() => {
+    const set = new Set<string>()
     entriesStartingWith.forEach((term: FvWord) => {
+      // Adding image urls
       if (term.img) {
-        mediaCount += 1
+        set.add(term.img)
       }
-      if (term.audio) {
-        mediaCount += term.audio.length
-      }
+
+      // Adding all audio urls
+      term.audio?.forEach((a: Audio1) => set.add(a.filename))
     })
-    return mediaCount
+    return Array.from(set)
+  }, [entriesStartingWith])
+
+  useEffect(() => {
+    // To prevent setting state on an unmounted component in case
+    // the async function finishes after the user has moved away
+    let isMounted = true
+
+    async function checkCache() {
+      if (mediaList.length === 0) {
+        if (isMounted) setAreAssetsCached(true)
+        return
+      }
+
+      const db = new IndexedDBService('firstVoicesIndexedDb')
+      const result = await db.hasAllMediaFiles(mediaList)
+
+      if (isMounted) setAreAssetsCached(result)
+    }
+
+    checkCache()
+
+    return () => {
+      isMounted = false
+    }
+  }, [mediaList])
+
+  let buttonLabel = ''
+
+  if (mediaList.length === 0) {
+    buttonLabel = 'No related media'
+  } else if (areAssetsCached) {
+    buttonLabel = 'All media downloaded'
+  } else {
+    buttonLabel = 'Download related media files'
   }
-  const buttonDisabled = getMediaCount() === 0
+  const buttonDisabled = mediaList.length === 0 || areAssetsCached || currentlyDownloading
 
   return (
     <>
@@ -55,7 +92,7 @@ export function DownloadButton({ dictionaryData, selected }: Readonly<DownloadBu
           }
         >
           <p className="text-xl">
-            Download related media files <span className="fv-cloud-arrow-down-regular justify-self-end" />
+            {buttonLabel} <span className="fv-cloud-arrow-down-regular justify-self-end" />
           </p>
         </button>
       </div>

--- a/src/services/indexedDbService.ts
+++ b/src/services/indexedDbService.ts
@@ -2,6 +2,7 @@ import { openDB, DBSchema, IDBPDatabase } from 'idb'
 
 // FPCC
 import { Bookmark } from 'components/common/data'
+import { normalizeUrl } from 'serviceWorker/media/mediaUtils'
 
 export interface StoredMediaFile {
   // Files are stored as ArrayBuffers instead of Blobs to work around webkit/ios bugs.
@@ -145,6 +146,15 @@ export class IndexedDBService {
   async getMediaCount(): Promise<number> {
     const store = await this.getReadOnlyMediaStore()
     return store.count()
+  }
+
+  async hasAllMediaFiles(urls: string[]): Promise<boolean> {
+    for (const url of urls) {
+      const normalized = normalizeUrl(url)
+      const exists = await this.hasMediaFile(normalized.toString())
+      if (!exists) return false
+    }
+    return true
   }
 
   async saveData(key: string, data: any) {


### PR DESCRIPTION
### Description of Changes
- Added hasAllMediaFiles utility to check for urls in the Db
- Added a checkCache utility in download-button
- Added checkCaching state in the download button to prevent flickers while application is checking the cache

### Checklist

- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~

### Reviewers Should Do The Following:

- [x] Review the changes here
- ~Pull the branch and test locally~

### Additional Notes

N/A
