### PR TITLE
FW-7116 icon adjustments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ node_modules
 
 # IDE - VSCode
 .vscode/*
-!.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json

--- a/src/components/common/audio-control/audio-control.tsx
+++ b/src/components/common/audio-control/audio-control.tsx
@@ -47,7 +47,7 @@ export function AudioControl({ audioSrc, description, styleType }: Readonly<Audi
         <button
           data-testid={`audio-btn-${audioSrc}`}
           type="button"
-          className={classNames('btn-contained bg-primary-500', {
+          className={classNames('btn-contained', {
             'opacity-30 bg-gray-500': !audioAvailable,
           })}
           onClick={() => {
@@ -62,7 +62,7 @@ export function AudioControl({ audioSrc, description, styleType }: Readonly<Audi
           }}
         >
           {audioPlaying ? <FaStop /> : <FaVolumeHigh />}
-          {description && <div>{description}</div>}
+          <div>{description || 'Speaker'}</div>
         </button>
       )}
 

--- a/src/components/dictionary-view/word-card-desktop.tsx
+++ b/src/components/dictionary-view/word-card-desktop.tsx
@@ -24,6 +24,7 @@ function WordCardDesktop({ item, wordWidthClass }: Readonly<WordCardDesktopProps
   return (
     <>
       <button
+        data-testid="word-card-dt-btn"
         className="hidden md:block rounded-lg bg-white p-6 m-1 shadow-lg hover:bg-gray-100 cursor-pointer w-full mx-2"
         onClick={() => setShowModal(true)}
       >
@@ -33,12 +34,12 @@ function WordCardDesktop({ item, wordWidthClass }: Readonly<WordCardDesktopProps
               {wordLocations ? applyHighlighting(word, wordLocations, 'word') : word}
             </div>
           </div>
-          <div className="col-span-1 flex justify-center items-center">
+          <div className="col-span-1 flex flex-wrap justify-center items-center">
             {audio?.map((mtAudio: Audio1) => (
-              <FaVolumeHigh key={mtAudio.filename} />
+              <FaVolumeHigh key={mtAudio.filename} className="inline-flex mr-2 text-xl" />
             ))}
           </div>
-          <div className="col-span-7 text-left">
+          <div className="col-span-7 text-left flex items-center pl-2">
             <p className="truncate">
               {wordLocations ? applyHighlighting(definition, wordLocations, 'definition') : definition}
             </p>

--- a/src/components/dictionary-view/word-card-mobile.tsx
+++ b/src/components/dictionary-view/word-card-mobile.tsx
@@ -34,9 +34,9 @@ function WordCardMobile({ item }: Readonly<WordCardMobileProps>) {
               {wordLocations ? applyHighlighting(definition, wordLocations, 'definition') : definition}
             </p>
           </div>
-          <div className="col-span-1 flex items-center justify-center">
+          <div className="col-span-1 flex flex-wrap items-center justify-center">
             {audio?.map((mtAudio: Audio1) => (
-              <FaVolumeHigh key={mtAudio.filename} />
+              <FaVolumeHigh key={mtAudio.filename} className="inline-flex mr-2" />
             ))}
           </div>
           <div className="col-span-1 place-self-end self-center">

--- a/src/components/dictionary-view/word-categories.tsx
+++ b/src/components/dictionary-view/word-categories.tsx
@@ -47,7 +47,7 @@ function WordCategories({ term, categoryPressed }: Readonly<WordCategoriesProps>
         {primaryCategory !== undefined && (
           <Link
             to={`/categories/${primaryCategory.id}`}
-            className="btn-contained bg-tertiaryB-500 mr-1 whitespace-nowrap"
+            className="btn-outlined mr-1 whitespace-nowrap"
             onClick={categoryPressed}
           >
             {primaryCategory?.title}
@@ -56,7 +56,7 @@ function WordCategories({ term, categoryPressed }: Readonly<WordCategoriesProps>
         {secondaryCategory !== undefined && (
           <Link
             to={`/categories/${secondaryCategory.id}`}
-            className="btn-contained bg-tertiaryB-500 mr-1 whitespace-nowrap"
+            className="btn-outlined mr-1 whitespace-nowrap"
             onClick={categoryPressed}
           >
             {secondaryCategory?.title}


### PR DESCRIPTION
### Description of Changes

- Wrap audio icons when there are multiple
- Use "Speaker" as label when no speaker name available
- Bonus - change Category buttons to match web (gray contained -> blue outlined)

### Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
